### PR TITLE
Continuous integration and automatic releases with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+os: osx
+osx_image: xcode9.4
+language: generic
+
+env:
+  global:
+    # UNITY_USERNAME=
+    - secure: AidAA5n+T7ID7U10XCGheNe7lmk0z2uQTv8pWyNpNSAxcsjUmeXm0bNONwI7FgCYbl/Wue1QHGrQv8+2kSfH+GfyDI+k3M+9ylCRHRyF2h8OW8Ic5Uhc9v6XoDp5ioN/+taUZMLTs0mpIByDmQnPk3VX83MrIYNx8TzjDjIB00DKlqCC8OJPbtqYkb4lirCIyf+Kj9Z7KxxQFNHpli5krAZgV7kJs2oJrP34C3Og+qSO1b/pIy5kszeaNMFguvB3MySihYVAE4cIR08vbDKtnmXmJBN08axb3bIWOCGca5ickvw+RRPOspACg2LQqRzouwNL9U3tCMcui3EL5lgLGz7bUKLEkbI3WSXHgh7BFOOc1P20ZN6Df7Rhkm89L+yYhWKBaaAB5soz4gpccbNRZDjcHWImoV5LN7WsVgzyu9m+rCiZd+hyJzqcITMz3cofCzu8g3YO8E/YWEfWrrT6nhlAUQJm3a7LVBh34oNyo4KlUsPUQ85hzwTDCUu0sTx+lfRJMvEzLKQxMpHqVhlIoes/ryfaY4jvDef+Er7KPJMurigVsF/aBSfjFtvZcJOnVfel0UOOQP2MNlfWls/+5HOjozGmBWMRpWz6wzi92wz+qnnWNCxsQiIKZRQ3GmipTOhnJdOVLAW0kZ851Hqf6k/oF63U3zY8w4IiETjMFa0=
+    # UNITY_PASSWORD=
+    - secure: jpE4wqxm4mpLujz/7f1xOW9w386qTVp5alQ3be5EngPRgk/+wwQWoT2pLsQ/IEj4E1EfxTqJCtLNPh/KVs2CaOZ3hvRa1lZzCOlbUiOQp0KRxT+Xn+HW8oJ/hxGpYEXjIesD59QeM2waeZM0HvYMtwChDln6/seJwZZFKxPXUdVMMiEdnkawKXy95Xde9Roa/MztI+gt0t7cPKvekLIBzyh/DwUWs77Z7DFojhYKa2Rn8mDJDeTqU2TxnsRDhrIqmLcJ9A1q91M7NyY+rUqnIZO8yNVtl2xR5Obb2s+tPacYFk31wkRCOqpVg5A7t+QgaPwSHZCBHpyZLNswgvtVBaRPTWQieN6akdCboaa3q8eFJEs9q2V+ZhAtkMFyRISZeuNl0ynVdsb+BNtSDsiiojiDyggWbUOQ6IQDFmh8oUMcu7zQvNjc4xDRUvGm2krCx4j+CHtLd7rxoBRJsPJf20/geBQm9GzkxvZRprVdAB1SxboPawgHRrCp2MCBjto4agmkLSQ/8m/KHIB5Khx6FYnCQ4EJWsS+xJ1B1v5Pv/M77TEgOK9y+185PNX5WpR+jiDma8TGCzs9bt1eZ+Rivlt0CP+KrpiYbP4O2Mqy4tHBLd3FoToZr3ExIKRUXye3oAfLBbdv29Nlz18Rnrbci6mD5pVHiwGBKsK37NCPu04=
+
+
+before_install:
+  - brew install git-lfs python@2
+  - git lfs install
+  # Forked from https://raw.githubusercontent.com/sttz/install-unity/master/install-unity.py
+  - curl -o install-unity.py https://raw.githubusercontent.com/rgov/install-unity/activate/install-unity.py
+  - mkdir unity-data
+
+install:
+  - sudo $(brew --prefix python@2)/bin/python2 install-unity.py -v --package Unity --package Windows-Mono --package Linux --data-dir unity-data 2018.2.0f2
+  - sudo chown -R "$USER" unity-data
+  - $(brew --prefix python@2)/bin/python2 install-unity.py -v --activate --email "$UNITY_USERNAME" --password "$UNITY_PASSWORD" --data-dir unity-data 2018.2.0f2
+
+before_script:
+  - git lfs pull
+
+script:
+  - travis_wait 90 /Applications/Unity/Unity.app/Contents/MacOS/Unity -quit -batchmode -projectPath . -executeMethod BuildFactory.BuildAll
+
+deploy:
+  provider: releases
+  api_key:
+    secure: VPPx3/VNkGh9TgDngd+O88/1sH17ToSWMvBbQ0GoJ4/bKLWy8AgVaDJSdKoZN2/4aijuASj4Fq57dSV5brS7U0NHnggh+fepieRhS9sCrEeFFUE4Yq48oIqz7cu21Ixn+P1AGfe1kmQALqXxhD1gnV55kjL5i/IibpnAql9yse3KhdAB5n+vKPHXbezk78tzvJluy0Oq5A1pLFlVJxcW5pUzAuV+lG92EcLKqDMejq8I4ggD1Z4NPnoll8hh2S1w827NgOx3+UDA7YWJ3iuAFYAE+Dkahs0UqV72e6fTOureQg7URufvFrpXHSpqlEfzgVq3gfXV5pl43uqLTQKVefvMf4AGg2tIDniOlyhx2nH8w2vFdbbTfDFBi9bNiy9DsxjJKI3DusRQeY8Fs8d0MAe9pv/QcTVAr20lIbF32gMZXDAu49yIlrKWDlLY4LGhxw0wnSaXv0aZrzDcm1w+eOZj7thk8rp7n6Fkf0Pv18sj4E/OPRjkBiTMmZhTMwv6g2iNOHDjslT0G+g/89P+W+TaPkWauYc4JN4G0ScHncOIUdAH8NTZbqpapxf+vkzOvufbuuO7rTXU5r6/qfrmT/9xwe2mzb/HMkTwVHQtPDdWYdpzf7uuQ7rvFiirpBAY9qo2EC7kmpNsU3qzvXiS1bGgCaaGjS3sGFeiodc6fPc=
+  file_glob: true
+  file: Build/*.zip
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ env:
     # UNITY_PASSWORD=
     - secure: jpE4wqxm4mpLujz/7f1xOW9w386qTVp5alQ3be5EngPRgk/+wwQWoT2pLsQ/IEj4E1EfxTqJCtLNPh/KVs2CaOZ3hvRa1lZzCOlbUiOQp0KRxT+Xn+HW8oJ/hxGpYEXjIesD59QeM2waeZM0HvYMtwChDln6/seJwZZFKxPXUdVMMiEdnkawKXy95Xde9Roa/MztI+gt0t7cPKvekLIBzyh/DwUWs77Z7DFojhYKa2Rn8mDJDeTqU2TxnsRDhrIqmLcJ9A1q91M7NyY+rUqnIZO8yNVtl2xR5Obb2s+tPacYFk31wkRCOqpVg5A7t+QgaPwSHZCBHpyZLNswgvtVBaRPTWQieN6akdCboaa3q8eFJEs9q2V+ZhAtkMFyRISZeuNl0ynVdsb+BNtSDsiiojiDyggWbUOQ6IQDFmh8oUMcu7zQvNjc4xDRUvGm2krCx4j+CHtLd7rxoBRJsPJf20/geBQm9GzkxvZRprVdAB1SxboPawgHRrCp2MCBjto4agmkLSQ/8m/KHIB5Khx6FYnCQ4EJWsS+xJ1B1v5Pv/M77TEgOK9y+185PNX5WpR+jiDma8TGCzs9bt1eZ+Rivlt0CP+KrpiYbP4O2Mqy4tHBLd3FoToZr3ExIKRUXye3oAfLBbdv29Nlz18Rnrbci6mD5pVHiwGBKsK37NCPu04=
 
+matrix:
+  include:
+    - name: macOS
+      env: BUILD_METHOD=BuildFactory.BuildOsx
+    - name: Windows
+      env: BUILD_METHOD=BuildFactory.BuildWin
+    - name: Linux
+      env: BUILD_METHOD=BuildFactory.BuildLinux
 
 before_install:
   - brew install git-lfs python@2
@@ -26,7 +34,7 @@ before_script:
   - git lfs pull
 
 script:
-  - travis_wait 90 /Applications/Unity/Unity.app/Contents/MacOS/Unity -quit -batchmode -projectPath . -executeMethod BuildFactory.BuildAll
+  - travis_wait 90 /Applications/Unity/Unity.app/Contents/MacOS/Unity -quit -batchmode -projectPath . -executeMethod "$BUILD_METHOD"
 
 deploy:
   provider: releases

--- a/Assets/Scripts/Editor/BuildPipeline.cs
+++ b/Assets/Scripts/Editor/BuildPipeline.cs
@@ -43,7 +43,13 @@ public class BuildFactory
         BuildRelease(BuildTarget.StandaloneWindows64, true);
     }
 
-    [MenuItem("Mytools/Build Release/OSx")]
+    [MenuItem("Mytools/Build Release/Linux")]
+    public static void BuildLinux()
+    {
+        BuildRelease(BuildTarget.StandaloneLinux64);
+    }
+
+    [MenuItem("Mytools/Build Release/macOS")]
     public static void BuildOsx()
     {
         BuildRelease(BuildTarget.StandaloneOSX);

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you're an artist and want to contribute 3D models, sounds, concept art:
 #### Developers
 If you know how to code and want to hack on the engine:
 
-1. Install [Unity 5](http://unity3d.com/get-unity). (We're using the Personal Edition, and either the classic installer or Unity Hub is fine.)
+1. Install [Unity 2018.2.0f2](http://unity3d.com/get-unity). (We're using the Personal Edition, and either the classic installer or Unity Hub is fine.)
 2. Non-Windows users: install the [Git LFS](https://git-lfs.github.com/) extension if you haven't already (testable with `git lfs version`).
 3. `$ git clone --recurse-submodules --depth 1 https://github.com/JapaMala/armok-vision.git` (or without `--depth 1` if you want the full history, but it's pretty big).
 4. Load the `armok-vision` folder in the Unity editor.

--- a/ReleaseFiles/Credits.txt
+++ b/ReleaseFiles/Credits.txt
@@ -12,6 +12,7 @@ Contributors, who have submitted work to Armok Vision:
   Ola Tuvesson
   Jack Leicester
   /u/loafoveryonder
+  Ryan Govostes
 
 Supporters, who have helped with Japa's upkeep on Patreon:
   Alex


### PR DESCRIPTION
I noticed that you were unable to release a macOS version of 0.19.1 due to hardware issues, so I tried to see if I could use Travis CI to automatically build it for you. It turned out to be pretty difficult!

This pull request adds a .travis.yml file that teaches Travis to install Unity 2018.2.0f2 and subsequently build Armok Vision for macOS, Windows, and Linux. Finally, it can also automatically upload the build artifacts to GitHub.

Note that you will need to make some changes after this has been merged in.

- [ ] You will need to replace the encrypted configuration fields that are specific to my fork. You will need the `travis` command line tool.

  - [ ] Encrypt your GitHub access token. I would suggest running `travis setup releases --force`; the answers don't matter except for `Encrypt API key? yes`. Then grab the `api_key` from .travis.yml, discard all of the changes to that file, then paste it in yourself.
  - [ ] Encrypt your Unity account e-mail with `travis encrypt UNITY_USERNAME="foobar@example.com"` and paste the result into .travis.yml where noted.
  - [ ] Likewise, encrypt your Unity account password with `travis encrypt UNITY_PASSWORD="xyzzy"`.

Note that Travis CI attempts to sanitize these sensitive values from build logs, but they could be accessed if Travis CI is hacked. If you're paranoid, you could set up a separate account for Unity, but make sure you go through the activation process at least once on your own machine.

- [ ] Once that's ready, you need to [activate this repo](http://travis-ci.org/JapaMala/armok-vision) on Travis CI.

Automatic releases work like this: If you push a new tag, Travis CI will build that tagged version and then create a new release with the same name as the tag, with the tagged commit message as the description, and attach the built binaries.